### PR TITLE
Two different ways of installing the VC redist

### DIFF
--- a/platforms/Windows/bundle/installer.wixproj
+++ b/platforms/Windows/bundle/installer.wixproj
@@ -4,6 +4,8 @@
     <DefaultCompressionLevel>$(BundleCompressionLevel)</DefaultCompressionLevel>
     <DefineConstants>
       $(DefineConstants);
+      VCREDIST_INSTALLER=$(VCREDIST_INSTALLER);
+      VCREDIST_VERSION=$(VCREDIST_VERSION);
       INCLUDE_X86_SDK=$(INCLUDE_X86_SDK);
       INCLUDE_ARM64_SDK=$(INCLUDE_ARM64_SDK);
     </DefineConstants>

--- a/platforms/Windows/bundle/installer.wxs
+++ b/platforms/Windows/bundle/installer.wxs
@@ -59,6 +59,25 @@
     -->
 
     <Chain>
+      <?if $(VCREDIST_INSTALLER) != ""?>
+        <ExePackage
+          SourceFile="$(VCREDIST_INSTALLER)"
+          InstallCondition="OptionsInstallRtl"
+          Permanent="yes"
+          InstallArguments="/install /quiet /norestart"
+          DownloadUrl="$(BaseReleaseDownloadUrl)/{2}">
+          <!--
+            Install only if not already in Add/Remove Programs
+            under the GUID below.
+            TODO: Is this the right GUID for arm64?
+          -->
+          <ArpEntry 
+            Id="9e10fdb5-a50b-4c3b-98a4-aefac04e5970"
+            Version="$(VCREDIST_VERSION)"
+            Win64="yes" />
+        </ExePackage>
+      <?endif?>
+
       <MsiPackage
         SourceFile="!(bindpath.rtl)\rtl.msi"
         InstallCondition="OptionsInstallRtl"


### PR DESCRIPTION
Either as an exe package (preferred), or by extracting the MSMs (deprecated for serviceability reasons)